### PR TITLE
Refine quote wizard with multi-step flow and estimate summary

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -17,9 +17,7 @@ export default function ContactPage() {
         <section className="pt-32 pb-20">
           <div className="mx-auto max-w-6xl px-6">
             <h1 className="text-4xl font-extrabold text-white mb-8">Contact</h1>
-            <div className="max-w-2xl mx-auto bg-light-bg border border-gray-700 p-8 rounded-xl">
-              <QuoteForm />
-            </div>
+            <QuoteForm />
           </div>
         </section>
       </main>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -43,11 +43,11 @@ body { background: var(--background); color: var(--foreground); }
 
 /* prototype helpers you had */
 .form-input {
-  @apply bg-[--color-card-bg] border border-gray-600 text-gray-200 focus:outline-none;
+  @apply bg-[--color-card-bg] border border-gray-500 text-gray-200 focus:outline-none;
   @apply focus:border-[--color-brand-blue-500] focus:ring-2;
   box-shadow: 0 0 0 0 rgba(0,0,0,0);
 }
-.option-card { @apply border-2 border-gray-600 transition-all; }
+.option-card { @apply border-2 border-gray-500 transition-all; }
 .option-card.selected { @apply border-[--color-brand-blue-500] bg-[--color-light-bg] -translate-y-0.5 shadow-lg; }
 .progress-bar-fill { transition: width .3s ease-in-out; }
 .fade-in-section { opacity: 0; transform: translateY(20px); transition: opacity .6s ease-out, transform .6s ease-out; }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,8 +8,6 @@ import Work from "@/components/Work";
 import Pricing from "@/components/Pricing";
 import Maintenance from "@/components/Maintenance";
 import About from "@/components/About";
-import Faq from "@/components/Faq";
-import Guarantee from "@/components/Guarantee";
 import Contact from "@/components/Contact";
 import Schedule from "@/components/Schedule";
 
@@ -25,8 +23,6 @@ export default function Page() {
         <Pricing />
         <Maintenance />
         <About />
-        <Faq />
-        <Guarantee />
         <Contact />
         <Schedule />
       </main>

--- a/src/app/website-quote/page.tsx
+++ b/src/app/website-quote/page.tsx
@@ -20,9 +20,7 @@ export default function WebsiteQuotePage() {
             <p className="text-gray-300 mb-8">
               I’ll follow up with options, timelines, and a clear price. No pressure.
             </p>
-            <div className="max-w-2xl mx-auto bg-light-bg border border-gray-700 p-8 rounded-xl">
-              <QuoteForm />
-            </div>
+            <QuoteForm />
           </div>
         </section>
       </main>

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -12,10 +12,8 @@ export default function Contact() {
           Answer a few questions to get a ballpark price
         </h2>
 
-        {/* centered calculator card */}
-        <div className="max-w-2xl mx-auto bg-light-bg border border-gray-700 p-8 rounded-xl">
-          <QuoteForm />
-        </div>
+        {/* quote form */}
+        <QuoteForm />
       </div>
     </section>
   );

--- a/src/components/QuoteForm.tsx
+++ b/src/components/QuoteForm.tsx
@@ -18,9 +18,8 @@ type StepId =
   | 'step-final';
 
 type Choice = { value: string; cost?: number; text: string };
-type Lead = { name: string; email: string };
+type Lead = { name: string; email: string; message?: string };
 
-/** Concrete shape (no conditional mapped types) */
 type Selections = {
   'step-1': Choice | null;
   'step-new-2': Choice | null;
@@ -56,7 +55,7 @@ const Section: React.FC<{ id?: string; className?: string; children: React.React
           obs.unobserve(entry.target);
         }
       },
-      { threshold: 0.12 }
+      { threshold: 0.12 },
     );
     obs.observe(el);
     return () => obs.disconnect();
@@ -105,11 +104,11 @@ export default function QuoteForm() {
     const seq: StepId[] = ['step-1'];
     if (type === 'new') {
       seq.push('step-new-2', 'step-features');
-      if ((selections['step-features'] as Choice[]).some((f) => f.value === 'ecommerce')) seq.push('step-ecomm');
+      if (selections['step-features'].some((f) => f.value === 'ecommerce')) seq.push('step-ecomm');
       seq.push('step-lead-capture', 'step-estimate', 'step-timeline', 'step-final');
     } else if (type === 'redesign') {
       seq.push('step-redesign-2', 'step-redesign-3', 'step-features');
-      if ((selections['step-features'] as Choice[]).some((f) => f.value === 'ecommerce')) seq.push('step-ecomm');
+      if (selections['step-features'].some((f) => f.value === 'ecommerce')) seq.push('step-ecomm');
       seq.push('step-lead-capture', 'step-estimate', 'step-timeline', 'step-final');
     } else if (type === 'other') {
       seq.push('step-other-2');
@@ -133,60 +132,64 @@ export default function QuoteForm() {
     if (step === 'step-other-ai') return !!selections['step-other-ai'];
     if (step === 'step-ecomm') return !!selections['step-ecomm'];
     if (step === 'step-timeline') return !!selections['step-timeline'];
-    if (step === 'step-lead-capture') return !!selections['step-lead-capture']?.name && !!selections['step-lead-capture']?.email;
+    if (step === 'step-lead-capture')
+      return Boolean(selections['step-lead-capture']?.name && selections['step-lead-capture']?.email);
     return true;
   };
 
   const go = (direction: 1 | -1) => {
     const seq = stepSequence();
-    const idx = Math.max(0, seq.indexOf(currentStep));
+    const idx = seq.indexOf(currentStep);
     const nextIdx = idx + direction;
-    if (nextIdx >= 0 && nextIdx < seq.length && isStepComplete(seq[idx])) {
+    if (nextIdx >= 0 && nextIdx < seq.length && isStepComplete(currentStep)) {
       setCurrentStep(seq[nextIdx]);
     }
   };
 
-  // steps that are multi-select vs single-select
-  const MULTI_STEPS = new Set<StepId>(['step-features', 'step-redesign-3']);
-  const SINGLE_STEPS = new Set<StepId>([
-    'step-1',
-    'step-new-2',
-    'step-other-2',
-    'step-other-seo',
-    'step-other-ads',
-    'step-other-ai',
-    'step-ecomm',
-    'step-timeline',
-  ]);
+  const reset = () => {
+    setSelections({
+      'step-1': null,
+      'step-new-2': null,
+      'step-redesign-2': { url: '' },
+      'step-redesign-3': [],
+      'step-other-2': null,
+      'step-other-seo': null,
+      'step-other-ads': null,
+      'step-other-ai': null,
+      'step-features': [],
+      'step-ecomm': null,
+      'step-timeline': null,
+      'step-lead-capture': null,
+      'step-estimate': null,
+      'step-final': null,
+    });
+    setExplanation('');
+    setCurrentStep('step-1');
+  };
 
+  const MULTI_STEPS = new Set<StepId>(['step-features', 'step-redesign-3']);
   const pick = (step: StepId, choice: Choice, options?: { checkbox?: boolean }) => {
     setSelections((prev) => {
       const next: Selections = { ...prev };
-
       if (options?.checkbox && MULTI_STEPS.has(step)) {
         const key = step as 'step-features' | 'step-redesign-3';
-        const current = next[key];
-        const exists = current.some((x) => x.value === choice.value);
-        const updated = exists ? current.filter((x) => x.value !== choice.value) : [...current, choice];
-        next[key] = updated;
-
+        const exists = next[key].some((c) => c.value === choice.value);
+        next[key] = exists ? next[key].filter((c) => c.value !== choice.value) : [...next[key], choice];
         if (key === 'step-features' && choice.value === 'ecommerce' && exists) {
           next['step-ecomm'] = null;
         }
-      } else if (SINGLE_STEPS.has(step)) {
-        const key =
-          step as
-            | 'step-1'
-            | 'step-new-2'
-            | 'step-other-2'
-            | 'step-other-seo'
-            | 'step-other-ads'
-            | 'step-other-ai'
-            | 'step-ecomm'
-            | 'step-timeline';
+      } else {
+        const key = step as
+          | 'step-1'
+          | 'step-new-2'
+          | 'step-other-2'
+          | 'step-other-seo'
+          | 'step-other-ads'
+          | 'step-other-ai'
+          | 'step-ecomm'
+          | 'step-timeline';
         next[key] = choice;
       }
-      // ignore other steps (like step-redesign-2 URL, lead capture, etc.) — they have their own handlers
       return next;
     });
   };
@@ -196,8 +199,12 @@ export default function QuoteForm() {
     const fd = new FormData(e.currentTarget);
     const name = String(fd.get('name') || '');
     const email = String(fd.get('email') || '');
+    const message = String(fd.get('message') || '');
     if (name && email) {
-      setSelections((prev) => ({ ...prev, 'step-lead-capture': { name, email } }));
+      setSelections((prev) => ({
+        ...prev,
+        'step-lead-capture': { name, email, message: message || undefined },
+      }));
       go(1);
     }
   };
@@ -206,11 +213,27 @@ export default function QuoteForm() {
     const s = selections;
     let total = 0;
     if (s['step-1']?.value === 'new') total += s['step-new-2']?.cost || 0;
-    if (s['step-1']?.value === 'redesign') s['step-redesign-3'].forEach((f) => (total += f.cost || 0));
+    if (s['step-1']?.value === 'redesign') s['step-redesign-3'].forEach((g) => (total += g.cost || 0));
     s['step-features'].forEach((f) => (total += f.cost || 0));
     if (s['step-ecomm']?.cost) total += s['step-ecomm'].cost;
     const max = Math.round(total * 1.35);
     return { min: total, max };
+  };
+
+  const buildSummary = () => {
+    const s = selections;
+    const items: string[] = [];
+    if (s['step-1']) items.push(`Project Type: ${s['step-1'].text}`);
+    if (s['step-new-2']) items.push(`Pages: ${s['step-new-2'].text}`);
+    if (s['step-redesign-3'].length) items.push(`Goals: ${s['step-redesign-3'].map((g) => g.text).join(', ')}`);
+    if (s['step-other-2']) items.push(`Inquiry: ${s['step-other-2'].text}`);
+    if (s['step-other-seo']) items.push(`SEO Goal: ${s['step-other-seo'].text}`);
+    if (s['step-other-ads']) items.push(`Ad Budget: ${s['step-other-ads'].text}`);
+    if (s['step-other-ai']) items.push(`AI Goal: ${s['step-other-ai'].text}`);
+    if (s['step-features'].length) items.push(`Features: ${s['step-features'].map((f) => f.text).join(', ')}`);
+    if (s['step-ecomm']) items.push(`Products: ${s['step-ecomm'].text}`);
+    if (s['step-timeline']) items.push(`Start: ${s['step-timeline'].text}`);
+    return items;
   };
 
   const getExplanation = async () => {
@@ -218,26 +241,7 @@ export default function QuoteForm() {
     setExplanation('');
     try {
       const { min, max } = estimateRange();
-
-      const parts: string[] = [];
-      const push = (label: string, c: Choice | null | undefined) => c && parts.push(`${label}: ${c.text}`);
-      push('Project', selections['step-1']);
-      push('Pages', selections['step-new-2']);
-      if (selections['step-redesign-3'].length) {
-        parts.push(`Goals: ${selections['step-redesign-3'].map((g) => g.text).join(', ')}`);
-      }
-      push('Inquiry', selections['step-other-2']);
-      push('SEO', selections['step-other-seo']);
-      push('Ads', selections['step-other-ads']);
-      push('AI', selections['step-other-ai']);
-      if (selections['step-features'].length) {
-        parts.push(`Features: ${selections['step-features'].map((f) => f.text).join(', ')}`);
-      }
-      push('Products', selections['step-ecomm']);
-      push('Timeline', selections['step-timeline']);
-
-      const summary = parts.join('; ');
-
+      const summary = buildSummary().join('; ');
       const res = await fetch('/api/quote/explain', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -254,7 +258,323 @@ export default function QuoteForm() {
   };
 
   const seq = stepSequence();
-  const progressPct = ((seq.indexOf(currentStep) + 1) / Math.max(seq.length, 1)) * 100;
+  const progressPct = (seq.indexOf(currentStep) / Math.max(seq.length - 1, 1)) * 100;
+
+  const OptionCard = ({
+    step,
+    option,
+    selected,
+    checkbox,
+  }: {
+    step: StepId;
+    option: Choice;
+    selected: boolean;
+    checkbox?: boolean;
+  }) => (
+    <button
+      type="button"
+      onClick={() => pick(step, option, { checkbox })}
+      className={[
+        'option-card rounded-lg px-4 py-3 text-sm flex items-center',
+        selected ? 'selected' : '',
+      ].join(' ')}
+    >
+      {checkbox && (
+        <input type="checkbox" checked={selected} readOnly className="h-4 w-4 mr-2 pointer-events-none" />
+      )}
+      <span className="flex-1 text-left">{option.text}</span>
+    </button>
+  );
+
+  const renderStep = () => {
+    switch (currentStep) {
+      case 'step-1':
+        return (
+          <div className="space-y-4">
+            <p className="text-gray-300">What type of project is this?</p>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+              {[
+                { value: 'new', text: 'New Website', cost: 0 },
+                { value: 'redesign', text: 'Redesign', cost: 0 },
+                { value: 'other', text: 'Other', cost: 0 },
+              ].map((opt) => (
+                <OptionCard
+                  key={opt.value}
+                  step="step-1"
+                  option={opt}
+                  selected={selections['step-1']?.value === opt.value}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      case 'step-new-2':
+        return (
+          <div className="space-y-4">
+            <p className="text-gray-300">Roughly how many pages will you need?</p>
+            <div className="grid grid-cols-1 gap-3">
+              {[
+                { value: '1-3', text: 'Starter (1-3 pages)', cost: 1500 },
+                { value: '4-8', text: 'Business (4-8 pages)', cost: 3000 },
+                { value: '8+', text: 'Premium (8+ pages)', cost: 5000 },
+              ].map((opt) => (
+                <OptionCard
+                  key={opt.value}
+                  step="step-new-2"
+                  option={opt}
+                  selected={selections['step-new-2']?.value === opt.value}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      case 'step-redesign-2':
+        return (
+          <div className="space-y-4">
+            <p className="text-gray-300">What is your current website URL?</p>
+            <input
+              type="url"
+              value={selections['step-redesign-2'].url}
+              onChange={(e) =>
+                setSelections((prev) => ({ ...prev, 'step-redesign-2': { url: e.target.value } }))
+              }
+              className="form-input w-full rounded-md px-3 py-2"
+              placeholder="https://example.com"
+            />
+          </div>
+        );
+      case 'step-redesign-3':
+        return (
+          <div className="space-y-4">
+            <p className="text-gray-300">What are your main goals for the redesign?</p>
+            <div className="grid grid-cols-1 gap-3">
+              {[
+                { value: 'modern', text: 'Modernize the Design', cost: 1000 },
+                { value: 'mobile', text: 'Improve Mobile Experience', cost: 800 },
+                { value: 'leads', text: 'Increase Leads/Sales', cost: 1500 },
+              ].map((opt) => (
+                <OptionCard
+                  key={opt.value}
+                  step="step-redesign-3"
+                  option={opt}
+                  checkbox
+                  selected={selections['step-redesign-3'].some((c) => c.value === opt.value)}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      case 'step-other-2':
+        return (
+          <div className="space-y-4">
+            <p className="text-gray-300">How can I help you?</p>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+              {[
+                { value: 'seo', text: 'SEO Services' },
+                { value: 'ads', text: 'Google Ads' },
+                { value: 'ai', text: 'AI / Automation' },
+              ].map((opt) => (
+                <OptionCard
+                  key={opt.value}
+                  step="step-other-2"
+                  option={opt}
+                  selected={selections['step-other-2']?.value === opt.value}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      case 'step-other-seo':
+        return (
+          <div className="space-y-4">
+            <p className="text-gray-300">What is your main SEO goal?</p>
+            <OptionCard
+              step="step-other-seo"
+              option={{ value: 'local-traffic', text: 'Increase local traffic' }}
+              selected={selections['step-other-seo']?.value === 'local-traffic'}
+            />
+          </div>
+        );
+      case 'step-other-ads':
+        return (
+          <div className="space-y-4">
+            <p className="text-gray-300">What is your estimated monthly budget?</p>
+            <OptionCard
+              step="step-other-ads"
+              option={{ value: 'under-1k', text: 'Under $1,000/mo' }}
+              selected={selections['step-other-ads']?.value === 'under-1k'}
+            />
+          </div>
+        );
+      case 'step-other-ai':
+        return (
+          <div className="space-y-4">
+            <p className="text-gray-300">What would you like to automate?</p>
+            <OptionCard
+              step="step-other-ai"
+              option={{ value: 'support', text: 'Customer Support' }}
+              selected={selections['step-other-ai']?.value === 'support'}
+            />
+          </div>
+        );
+      case 'step-features':
+        return (
+          <div className="space-y-4">
+            <p className="text-gray-300">Any additional features? (Optional)</p>
+            <div className="grid grid-cols-1 gap-3">
+              {[
+                { value: 'ecommerce', text: 'eCommerce / Online Store', cost: 2000 },
+                { value: 'seo', text: 'Initial SEO Setup', cost: 500 },
+                { value: 'logo', text: 'Logo Design / Branding', cost: 400 },
+              ].map((opt) => (
+                <OptionCard
+                  key={opt.value}
+                  step="step-features"
+                  option={opt}
+                  checkbox
+                  selected={selections['step-features'].some((c) => c.value === opt.value)}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      case 'step-ecomm':
+        return (
+          <div className="space-y-4">
+            <p className="text-gray-300">How many products will you sell?</p>
+            <div className="grid grid-cols-1 gap-3">
+              {[
+                { value: '1-10', text: 'Starter Store (1-10 Products)', cost: 500 },
+                { value: '11-50', text: 'Growing Store (11-50 Products)', cost: 1000 },
+                { value: '50+', text: 'Large Store (50+ Products)', cost: 2000 },
+              ].map((opt) => (
+                <OptionCard
+                  key={opt.value}
+                  step="step-ecomm"
+                  option={opt}
+                  selected={selections['step-ecomm']?.value === opt.value}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      case 'step-lead-capture': {
+        const isOther = selections['step-1']?.value === 'other';
+        return (
+          <form onSubmit={submitLead} className="space-y-4">
+            {isOther && (
+              <div>
+                <label className="block text-sm text-gray-300 mb-1">Message</label>
+                <textarea
+                  name="message"
+                  rows={3}
+                  className="form-input w-full rounded-md px-3 py-2"
+                  placeholder="Please provide some details..."
+                />
+              </div>
+            )}
+            <div className="grid md:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm text-gray-300 mb-1">Name *</label>
+                <input name="name" className="form-input w-full rounded-md px-3 py-2" required />
+              </div>
+              <div>
+                <label className="block text-sm text-gray-300 mb-1">Email *</label>
+                <input
+                  name="email"
+                  type="email"
+                  className="form-input w-full rounded-md px-3 py-2"
+                  required
+                />
+              </div>
+            </div>
+            <button className="bg-brand-blue-500 hover:bg-brand-blue-600 text-white px-5 py-2 rounded-lg">
+              {isOther ? 'Send Inquiry' : 'See My Estimate →'}
+            </button>
+          </form>
+        );
+      }
+      case 'step-estimate': {
+        const { min, max } = estimateRange();
+        return (
+          <div className="space-y-4 text-center">
+            <div className="p-4 border border-gray-600 rounded-lg text-left">
+              <h4 className="text-white font-semibold mb-2">Your Project Outline:</h4>
+              <ul className="list-disc list-inside text-gray-300 space-y-1">
+                {buildSummary().map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </div>
+            <p className="text-gray-200 text-3xl">
+              ${min.toLocaleString()} - ${max.toLocaleString()}
+            </p>
+            <button
+              onClick={getExplanation}
+              className="text-sm text-brand-blue-500 hover:text-brand-blue-400"
+              disabled={explaining}
+            >
+              {explaining ? 'Explaining…' : 'Why this price?'}
+            </button>
+            {explanation && <p className="text-gray-300 text-sm">{explanation}</p>}
+            <div className="flex flex-col md:flex-row gap-4 pt-4">
+              <button
+                type="button"
+                className="w-full bg-card-bg text-white px-6 py-3 rounded-lg font-semibold hover:bg-gray-600"
+                onClick={reset}
+              >
+                Adjust My Options
+              </button>
+              <button
+                type="button"
+                className="w-full bg-brand-blue-500 text-white px-6 py-3 rounded-lg font-semibold hover:bg-brand-blue-600"
+                onClick={() => go(1)}
+              >
+                Looks Good, What&apos;s Next?
+              </button>
+            </div>
+          </div>
+        );
+      }
+      case 'step-timeline':
+        return (
+          <div className="space-y-4">
+            <p className="text-gray-300">Great! How soon would you like to start?</p>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {[
+                { value: 'now', text: 'Immediately' },
+                { value: '1-2w', text: 'In 1-2 Weeks' },
+                { value: 'month', text: 'Within a Month' },
+                { value: 'browsing', text: 'Just Browsing' },
+              ].map((opt) => (
+                <OptionCard
+                  key={opt.value}
+                  step="step-timeline"
+                  option={opt}
+                  selected={selections['step-timeline']?.value === opt.value}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      case 'step-final': {
+        const name = selections['step-lead-capture']?.name.split(' ')[0] || '';
+        const isOther = selections['step-1']?.value === 'other';
+        return (
+          <div className="text-center space-y-2">
+            <h3 className="text-2xl font-bold text-white">
+              {isOther ? `Thank you, ${name}!` : 'Thank you!'}
+            </h3>
+            <p className="text-gray-400">
+              {isOther
+                ? "Your inquiry has been sent. I'll be in touch with you shortly."
+                : 'Your estimate has been saved. I will reach out with a formal proposal soon.'}
+            </p>
+          </div>
+        );
+      }
+    }
+  };
 
   return (
     <Section id="quote" className="bg-brand-blue-600/10">
@@ -265,103 +585,33 @@ export default function QuoteForm() {
             Answer a few questions to get a real-time price range for your project.
           </p>
         </div>
-
         <div className="max-w-2xl mx-auto bg-light-bg border border-gray-700 p-6 md:p-8 rounded-xl shadow-2xl">
-          {/* Progress bar */}
           <div className="w-full h-2 bg-gray-800 rounded-full overflow-hidden mb-6">
             <div className="h-full bg-brand-blue-500" style={{ width: `${progressPct}%` }} />
           </div>
 
-          {/* Step: project type */}
-          {currentStep === 'step-1' && (
-            <div className="space-y-4">
-              <p className="text-gray-300">What type of project is this?</p>
-              <div className="grid grid-cols-2 gap-3">
-                {[
-                  { value: 'new', text: 'New Website', cost: 1200 },
-                  { value: 'redesign', text: 'Redesign', cost: 800 },
-                  { value: 'other', text: 'Other / Help', cost: 0 },
-                ].map((opt) => (
-                  <button
-                    key={opt.value}
-                    type="button"
-                    onClick={() => {
-                      pick('step-1', opt);
-                      setTimeout(() => go(1), 150);
-                    }}
-                    className={[
-                      'option-card rounded-lg px-4 py-3 text-sm',
-                      selections['step-1']?.value === opt.value ? 'selected' : '',
-                    ].join(' ')}
-                  >
-                    {opt.text}
-                  </button>
-                ))}
-              </div>
-            </div>
-          )}
+          {renderStep()}
 
-          {/* Step: lead capture */}
-          {currentStep === 'step-lead-capture' && (
-            <form onSubmit={submitLead} className="space-y-4">
-              <div className="grid md:grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-sm text-gray-300 mb-1">Name *</label>
-                  <input name="name" className="form-input w-full rounded-md px-3 py-2" required />
-                </div>
-                <div>
-                  <label className="block text-sm text-gray-300 mb-1">Email *</label>
-                  <input name="email" type="email" className="form-input w-full rounded-md px-3 py-2" required />
-                </div>
-              </div>
-              <button className="bg-brand-blue-500 hover:bg-brand-blue-600 text-white px-5 py-2 rounded-lg">
-                Continue
-              </button>
-            </form>
-          )}
-
-          {/* Step: estimate */}
-          {currentStep === 'step-estimate' && (
-            <div className="space-y-4">
-              <h3 className="text-white font-semibold">Estimated Range</h3>
-              <p className="text-gray-200 text-xl">
-                {(() => {
-                  const { min, max } = estimateRange();
-                  return `$${min.toLocaleString()} – $${max.toLocaleString()}`;
-                })()}
-              </p>
-
+          {!['step-estimate', 'step-final'].includes(currentStep) && (
+            <div className="flex items-center justify-between pt-6">
               <button
-                onClick={getExplanation}
-                className="text-sm text-brand-blue-500 hover:text-brand-blue-400"
-                disabled={explaining}
+                type="button"
+                onClick={() => go(-1)}
+                className="text-sm text-gray-400 hover:text-white"
+                disabled={seq.indexOf(currentStep) <= 0}
               >
-                {explaining ? 'Explaining…' : 'Why this price?'}
+                Back
               </button>
-
-              {explanation && <p className="text-gray-300">{explanation}</p>}
+              <button
+                type="button"
+                onClick={() => go(1)}
+                className="bg-brand-blue-500 hover:bg-brand-blue-600 text-white px-5 py-2 rounded-lg disabled:opacity-60"
+                disabled={!isStepComplete(currentStep)}
+              >
+                Next
+              </button>
             </div>
           )}
-
-          {/* Wizard nav */}
-          <div className="flex items-center justify-between pt-6">
-            <button
-              type="button"
-              onClick={() => go(-1)}
-              className="text-sm text-gray-400 hover:text-white"
-              disabled={seq.indexOf(currentStep) <= 0}
-            >
-              Back
-            </button>
-            <button
-              type="button"
-              onClick={() => go(1)}
-              className="bg-brand-blue-500 hover:bg-brand-blue-600 text-white px-5 py-2 rounded-lg disabled:opacity-60"
-              disabled={!isStepComplete(currentStep) || seq.indexOf(currentStep) >= seq.length - 1}
-            >
-              Next
-            </button>
-          </div>
         </div>
       </div>
     </Section>

--- a/src/components/QuoteForm.tsx
+++ b/src/components/QuoteForm.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState } from 'react';
 
 type StepId =
   | 'step-1'
@@ -37,44 +37,6 @@ type Selections = {
   'step-final': null;
 };
 
-const Section: React.FC<{ id?: string; className?: string; children: React.ReactNode }> = ({
-  id,
-  className = '',
-  children,
-}) => {
-  const ref = useRef<HTMLElement | null>(null);
-  const [isVisible, setIsVisible] = useState(false);
-
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-    const obs = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setIsVisible(true);
-          obs.unobserve(entry.target);
-        }
-      },
-      { threshold: 0.12 },
-    );
-    obs.observe(el);
-    return () => obs.disconnect();
-  }, []);
-
-  return (
-    <section
-      id={id}
-      ref={ref}
-      className={[
-        'py-20 lg:py-28 transition-opacity transition-transform duration-700 ease-out will-change-transform',
-        isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5',
-        className,
-      ].join(' ')}
-    >
-      {children}
-    </section>
-  );
-};
 
 export default function QuoteForm() {
   const [currentStep, setCurrentStep] = useState<StepId>('step-1');
@@ -141,7 +103,11 @@ export default function QuoteForm() {
     const seq = stepSequence();
     const idx = seq.indexOf(currentStep);
     const nextIdx = idx + direction;
-    if (nextIdx >= 0 && nextIdx < seq.length && isStepComplete(currentStep)) {
+    if (
+      nextIdx >= 0 &&
+      nextIdx < seq.length &&
+      (direction === -1 || isStepComplete(currentStep))
+    ) {
       setCurrentStep(seq[nextIdx]);
     }
   };
@@ -275,7 +241,7 @@ export default function QuoteForm() {
       type="button"
       onClick={() => pick(step, option, { checkbox })}
       className={[
-        'option-card rounded-lg px-4 py-3 text-sm flex items-center',
+        'option-card rounded-lg px-4 py-3 text-sm flex items-center text-gray-200',
         selected ? 'selected' : '',
       ].join(' ')}
     >
@@ -291,7 +257,7 @@ export default function QuoteForm() {
       case 'step-1':
         return (
           <div className="space-y-4">
-            <p className="text-gray-300">What type of project is this?</p>
+            <p className="text-gray-100">What type of project is this?</p>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
               {[
                 { value: 'new', text: 'New Website', cost: 0 },
@@ -311,7 +277,7 @@ export default function QuoteForm() {
       case 'step-new-2':
         return (
           <div className="space-y-4">
-            <p className="text-gray-300">Roughly how many pages will you need?</p>
+            <p className="text-gray-100">Roughly how many pages will you need?</p>
             <div className="grid grid-cols-1 gap-3">
               {[
                 { value: '1-3', text: 'Starter (1-3 pages)', cost: 1500 },
@@ -331,7 +297,7 @@ export default function QuoteForm() {
       case 'step-redesign-2':
         return (
           <div className="space-y-4">
-            <p className="text-gray-300">What is your current website URL?</p>
+            <p className="text-gray-100">What is your current website URL?</p>
             <input
               type="url"
               value={selections['step-redesign-2'].url}
@@ -346,7 +312,7 @@ export default function QuoteForm() {
       case 'step-redesign-3':
         return (
           <div className="space-y-4">
-            <p className="text-gray-300">What are your main goals for the redesign?</p>
+            <p className="text-gray-100">What are your main goals for the redesign?</p>
             <div className="grid grid-cols-1 gap-3">
               {[
                 { value: 'modern', text: 'Modernize the Design', cost: 1000 },
@@ -367,7 +333,7 @@ export default function QuoteForm() {
       case 'step-other-2':
         return (
           <div className="space-y-4">
-            <p className="text-gray-300">How can I help you?</p>
+            <p className="text-gray-100">How can I help you?</p>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
               {[
                 { value: 'seo', text: 'SEO Services' },
@@ -387,7 +353,7 @@ export default function QuoteForm() {
       case 'step-other-seo':
         return (
           <div className="space-y-4">
-            <p className="text-gray-300">What is your main SEO goal?</p>
+            <p className="text-gray-100">What is your main SEO goal?</p>
             <OptionCard
               step="step-other-seo"
               option={{ value: 'local-traffic', text: 'Increase local traffic' }}
@@ -398,7 +364,7 @@ export default function QuoteForm() {
       case 'step-other-ads':
         return (
           <div className="space-y-4">
-            <p className="text-gray-300">What is your estimated monthly budget?</p>
+            <p className="text-gray-100">What is your estimated monthly budget?</p>
             <OptionCard
               step="step-other-ads"
               option={{ value: 'under-1k', text: 'Under $1,000/mo' }}
@@ -409,7 +375,7 @@ export default function QuoteForm() {
       case 'step-other-ai':
         return (
           <div className="space-y-4">
-            <p className="text-gray-300">What would you like to automate?</p>
+            <p className="text-gray-100">What would you like to automate?</p>
             <OptionCard
               step="step-other-ai"
               option={{ value: 'support', text: 'Customer Support' }}
@@ -420,7 +386,7 @@ export default function QuoteForm() {
       case 'step-features':
         return (
           <div className="space-y-4">
-            <p className="text-gray-300">Any additional features? (Optional)</p>
+            <p className="text-gray-100">Any additional features? (Optional)</p>
             <div className="grid grid-cols-1 gap-3">
               {[
                 { value: 'ecommerce', text: 'eCommerce / Online Store', cost: 2000 },
@@ -441,7 +407,7 @@ export default function QuoteForm() {
       case 'step-ecomm':
         return (
           <div className="space-y-4">
-            <p className="text-gray-300">How many products will you sell?</p>
+            <p className="text-gray-100">How many products will you sell?</p>
             <div className="grid grid-cols-1 gap-3">
               {[
                 { value: '1-10', text: 'Starter Store (1-10 Products)', cost: 500 },
@@ -464,7 +430,7 @@ export default function QuoteForm() {
           <form onSubmit={submitLead} className="space-y-4">
             {isOther && (
               <div>
-                <label className="block text-sm text-gray-300 mb-1">Message</label>
+                <label className="block text-sm text-gray-100 mb-1">Message</label>
                 <textarea
                   name="message"
                   rows={3}
@@ -475,11 +441,11 @@ export default function QuoteForm() {
             )}
             <div className="grid md:grid-cols-2 gap-4">
               <div>
-                <label className="block text-sm text-gray-300 mb-1">Name *</label>
+                <label className="block text-sm text-gray-100 mb-1">Name *</label>
                 <input name="name" className="form-input w-full rounded-md px-3 py-2" required />
               </div>
               <div>
-                <label className="block text-sm text-gray-300 mb-1">Email *</label>
+                <label className="block text-sm text-gray-100 mb-1">Email *</label>
                 <input
                   name="email"
                   type="email"
@@ -500,7 +466,7 @@ export default function QuoteForm() {
           <div className="space-y-4 text-center">
             <div className="p-4 border border-gray-600 rounded-lg text-left">
               <h4 className="text-white font-semibold mb-2">Your Project Outline:</h4>
-              <ul className="list-disc list-inside text-gray-300 space-y-1">
+              <ul className="list-disc list-inside text-gray-100 space-y-1">
                 {buildSummary().map((item) => (
                   <li key={item}>{item}</li>
                 ))}
@@ -516,7 +482,7 @@ export default function QuoteForm() {
             >
               {explaining ? 'Explaining…' : 'Why this price?'}
             </button>
-            {explanation && <p className="text-gray-300 text-sm">{explanation}</p>}
+            {explanation && <p className="text-gray-100 text-sm">{explanation}</p>}
             <div className="flex flex-col md:flex-row gap-4 pt-4">
               <button
                 type="button"
@@ -539,7 +505,7 @@ export default function QuoteForm() {
       case 'step-timeline':
         return (
           <div className="space-y-4">
-            <p className="text-gray-300">Great! How soon would you like to start?</p>
+            <p className="text-gray-100">Great! How soon would you like to start?</p>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
               {[
                 { value: 'now', text: 'Immediately' },
@@ -577,43 +543,33 @@ export default function QuoteForm() {
   };
 
   return (
-    <Section id="quote" className="bg-brand-blue-600/10">
-      <div className="mx-auto max-w-6xl px-6">
-        <div className="text-center mb-10">
-          <h2 className="text-3xl md:text-4xl font-bold text-white">Get an Instant Estimate</h2>
-          <p className="text-lg text-blue-200 mt-2 max-w-2xl mx-auto">
-            Answer a few questions to get a real-time price range for your project.
-          </p>
-        </div>
-        <div className="max-w-2xl mx-auto bg-light-bg border border-gray-700 p-6 md:p-8 rounded-xl shadow-2xl">
-          <div className="w-full h-2 bg-gray-800 rounded-full overflow-hidden mb-6">
-            <div className="h-full bg-brand-blue-500" style={{ width: `${progressPct}%` }} />
-          </div>
-
-          {renderStep()}
-
-          {!['step-estimate', 'step-final'].includes(currentStep) && (
-            <div className="flex items-center justify-between pt-6">
-              <button
-                type="button"
-                onClick={() => go(-1)}
-                className="text-sm text-gray-400 hover:text-white"
-                disabled={seq.indexOf(currentStep) <= 0}
-              >
-                Back
-              </button>
-              <button
-                type="button"
-                onClick={() => go(1)}
-                className="bg-brand-blue-500 hover:bg-brand-blue-600 text-white px-5 py-2 rounded-lg disabled:opacity-60"
-                disabled={!isStepComplete(currentStep)}
-              >
-                Next
-              </button>
-            </div>
-          )}
-        </div>
+    <div className="max-w-3xl mx-auto bg-light-bg border border-gray-700 p-6 md:p-8 rounded-xl shadow-2xl">
+      <div className="w-full h-2 bg-gray-800 rounded-full overflow-hidden mb-6">
+        <div className="h-full bg-brand-blue-500" style={{ width: `${progressPct}%` }} />
       </div>
-    </Section>
+
+      {renderStep()}
+
+      {!['step-estimate', 'step-final'].includes(currentStep) && (
+        <div className="flex items-center justify-between pt-6">
+          <button
+            type="button"
+            onClick={() => go(-1)}
+            className="text-sm text-gray-400 hover:text-white disabled:opacity-40"
+            disabled={seq.indexOf(currentStep) <= 0}
+          >
+            Back
+          </button>
+          <button
+            type="button"
+            onClick={() => go(1)}
+            className="bg-brand-blue-500 hover:bg-brand-blue-600 text-white px-5 py-2 rounded-lg disabled:opacity-60"
+            disabled={!isStepComplete(currentStep)}
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- expand quote form into configurable multi-step wizard with new/redesign/other flows
- add feature and e-commerce options plus timeline and final thank-you screens
- provide project outline and price explanation in estimate step

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68979ab999f48326984b6ec6f8936128