### PR TITLE
Add simple admin CMS with login and portfolio management

### DIFF
--- a/data/portfolio.json
+++ b/data/portfolio.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "1",
+    "title": "Sample Project",
+    "description": "Initial portfolio item."
+  }
+]

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+
+interface PortfolioItem {
+  id: string;
+  title: string;
+  description: string;
+}
+
+export default function AdminPage() {
+  const [token, setToken] = useState<string | null>(null);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [items, setItems] = useState<PortfolioItem[]>([]);
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+
+  useEffect(() => {
+    const stored = typeof localStorage !== 'undefined' ? localStorage.getItem('token') : null;
+    if (stored) setToken(stored);
+  }, []);
+
+  const fetchItems = useCallback(async () => {
+    const res = await fetch('/api/portfolio', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) {
+      setItems(await res.json());
+    }
+  }, [token]);
+
+  useEffect(() => {
+    if (token) {
+      fetchItems();
+    }
+  }, [token, fetchItems]);
+
+  async function login(e: React.FormEvent) {
+    e.preventDefault();
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setToken(data.token);
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem('token', data.token);
+      }
+    } else {
+      alert('Invalid credentials');
+    }
+  }
+
+  async function addItem(e: React.FormEvent) {
+    e.preventDefault();
+    const res = await fetch('/api/portfolio', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ title, description }),
+    });
+    if (res.ok) {
+      const item = await res.json();
+      setItems([...items, item]);
+      setTitle('');
+      setDescription('');
+    }
+  }
+
+  async function remove(id: string) {
+    const res = await fetch(`/api/portfolio/${id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) {
+      setItems(items.filter((i) => i.id !== id));
+    }
+  }
+
+  if (!token) {
+    return (
+      <form onSubmit={login} className="p-4 space-y-2 max-w-sm">
+        <h1 className="text-xl font-bold">Admin Login</h1>
+        <input
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          placeholder="Username"
+          className="border p-2 w-full"
+        />
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+          className="border p-2 w-full"
+        />
+        <button type="submit" className="bg-blue-500 text-white px-4 py-2">
+          Login
+        </button>
+      </form>
+    );
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Portfolio Admin</h1>
+      <ul className="space-y-2">
+        {items.map((item) => (
+          <li key={item.id} className="flex items-center justify-between border p-2">
+            <div>
+              <strong>{item.title}</strong> - {item.description}
+            </div>
+            <button
+              onClick={() => remove(item.id)}
+              className="text-red-600 hover:underline"
+            >
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+      <form onSubmit={addItem} className="space-y-2 max-w-sm">
+        <h2 className="font-semibold">Add Item</h2>
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Title"
+          className="border p-2 w-full"
+        />
+        <input
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Description"
+          className="border p-2 w-full"
+        />
+        <button type="submit" className="bg-green-600 text-white px-4 py-2">
+          Add
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createSession } from '@/lib/auth';
+
+export async function POST(req: NextRequest) {
+  const { username, password } = await req.json();
+  if (username === 'admin' && password === 'password') {
+    const token = createSession();
+    return NextResponse.json({ token });
+  }
+  return new NextResponse('Unauthorized', { status: 401 });
+}

--- a/src/app/api/portfolio/[id]/route.ts
+++ b/src/app/api/portfolio/[id]/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verifySession } from '@/lib/auth';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const dataFile = path.join(process.cwd(), 'data', 'portfolio.json');
+
+interface PortfolioItem {
+  id: string;
+  title: string;
+  description: string;
+}
+
+function getToken(req: NextRequest): string | null {
+  const auth = req.headers.get('authorization');
+  return auth?.split(' ')[1] ?? null;
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const token = getToken(req);
+  if (!verifySession(token)) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+  const json = await fs.readFile(dataFile, 'utf-8');
+  const items: PortfolioItem[] = JSON.parse(json);
+  const index = items.findIndex((item) => item.id === params.id);
+  if (index === -1) {
+    return new NextResponse('Not Found', { status: 404 });
+  }
+  items.splice(index, 1);
+  await fs.writeFile(dataFile, JSON.stringify(items, null, 2));
+  return NextResponse.json({ success: true });
+}
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const token = getToken(req);
+  if (!verifySession(token)) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+  const { title, description } = await req.json();
+  const json = await fs.readFile(dataFile, 'utf-8');
+  const items: PortfolioItem[] = JSON.parse(json);
+  const index = items.findIndex((item) => item.id === params.id);
+  if (index === -1) {
+    return new NextResponse('Not Found', { status: 404 });
+  }
+  items[index] = { ...items[index], title, description };
+  await fs.writeFile(dataFile, JSON.stringify(items, null, 2));
+  return NextResponse.json(items[index]);
+}

--- a/src/app/api/portfolio/route.ts
+++ b/src/app/api/portfolio/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verifySession } from '@/lib/auth';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { randomUUID } from 'crypto';
+
+const dataFile = path.join(process.cwd(), 'data', 'portfolio.json');
+
+function getToken(req: NextRequest): string | null {
+  const auth = req.headers.get('authorization');
+  return auth?.split(' ')[1] ?? null;
+}
+
+export async function GET(req: NextRequest) {
+  const token = getToken(req);
+  if (!verifySession(token)) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+  const json = await fs.readFile(dataFile, 'utf-8');
+  const items = JSON.parse(json);
+  return NextResponse.json(items);
+}
+
+export async function POST(req: NextRequest) {
+  const token = getToken(req);
+  if (!verifySession(token)) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+  const { title, description } = await req.json();
+  const json = await fs.readFile(dataFile, 'utf-8');
+  const items = JSON.parse(json);
+  const newItem = { id: randomUUID(), title, description };
+  items.push(newItem);
+  await fs.writeFile(dataFile, JSON.stringify(items, null, 2));
+  return NextResponse.json(newItem, { status: 201 });
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,21 @@
+import { randomUUID } from 'crypto';
+
+const sessions = new Map<string, number>();
+const ONE_HOUR = 1000 * 60 * 60;
+
+export function createSession(): string {
+  const token = randomUUID();
+  const expires = Date.now() + ONE_HOUR;
+  sessions.set(token, expires);
+  return token;
+}
+
+export function verifySession(token: string | null): boolean {
+  if (!token) return false;
+  const expiry = sessions.get(token);
+  if (!expiry || Date.now() > expiry) {
+    sessions.delete(token);
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- implement in-memory session system for simple auth
- add login and portfolio CRUD API routes
- create basic admin page to manage portfolio entries

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6897ae320c4c83268a0e08933d20f086